### PR TITLE
Fix imports and redeclaration of structs

### DIFF
--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -17,17 +17,17 @@ package avcodec
 import "C"
 import (
 	"unsafe"
+	"github.com/giorgisio/goav/avutil"
 )
 
 type (
 	Codec                         C.struct_AVCodec
-	Context                       C.struct_AVCodecContext
+	CodecContext                  C.struct_AVCodecContext
 	Descriptor                    C.struct_AVCodecDescriptor
 	Parser                        C.struct_AVCodecParser
 	ParserContext                 C.struct_AVCodecParserContext
 	Dictionary                    C.struct_AVDictionary
 	Frame                         C.struct_AVFrame
-	MediaType                     C.enum_AVMediaType
 	Packet                        C.struct_AVPacket
 	BitStreamFilter               C.struct_AVBitStreamFilter
 	BitStreamFilterContext        C.struct_AVBitStreamFilterContext
@@ -76,8 +76,8 @@ func (c *Codec) AvGetProfileName(p int) string {
 }
 
 //Allocate an Context and set its fields to default values.
-func (c *Codec) AvcodecAllocContext3() *Context {
-	return (*Context)(C.avcodec_alloc_context3((*C.struct_AVCodec)(c)))
+func (c *Codec) AvcodecAllocContext3() *CodecContext {
+	return (*CodecContext)(C.avcodec_alloc_context3((*C.struct_AVCodec)(c)))
 }
 
 func (c *Codec) AvCodecIsEncoder() int {
@@ -179,7 +179,7 @@ func AvGetCodecTagString(b string, bf uintptr, c uint) uintptr {
 	return uintptr(C.av_get_codec_tag_string(C.CString(b), C.size_t(bf), C.uint(c)))
 }
 
-func AvcodecString(b string, bs int, ctxt *Context, e int) {
+func AvcodecString(b string, bs int, ctxt *CodecContext, e int) {
 	C.avcodec_string(C.CString(b), C.int(bs), (*C.struct_AVCodecContext)(ctxt), C.int(e))
 }
 
@@ -220,8 +220,8 @@ func (a *AvHWAccel) AvHwaccelNext() *AvHWAccel {
 }
 
 //Get the type of the given codec.
-func AvcodecGetType(c CodecId) MediaType {
-	return (MediaType)(C.avcodec_get_type((C.enum_AVCodecID)(c)))
+func AvcodecGetType(c CodecId) avutil.MediaType {
+	return (avutil.MediaType)(C.avcodec_get_type((C.enum_AVCodecID)(c)))
 }
 
 //Get the name of a codec.

--- a/avcodec/bitstreamfilter.go
+++ b/avcodec/bitstreamfilter.go
@@ -21,7 +21,7 @@ func (f *BitStreamFilter) AvBitstreamFilterNext() *BitStreamFilter {
 }
 
 //Filter bitstream.
-func (bfx *BitStreamFilterContext) AvBitstreamFilterFilter(ctxt *Context, a string, p **uint8, ps *int, b *uint8, bs, k int) int {
+func (bfx *BitStreamFilterContext) AvBitstreamFilterFilter(ctxt *CodecContext, a string, p **uint8, ps *int, b *uint8, bs, k int) int {
 	return int(C.av_bitstream_filter_filter((*C.struct_AVBitStreamFilterContext)(bfx), (*C.struct_AVCodecContext)(ctxt), C.CString(a), (**C.uint8_t)(unsafe.Pointer(p)), (*C.int)(unsafe.Pointer(ps)), (*C.uint8_t)(b), C.int(bs), C.int(k)))
 }
 

--- a/avcodec/context.go
+++ b/avcodec/context.go
@@ -10,139 +10,139 @@ import (
 	"unsafe"
 )
 
-func (ctxt *Context) AvCodecGetPktTimebase() Rational {
+func (ctxt *CodecContext) AvCodecGetPktTimebase() Rational {
 	return (Rational)(C.av_codec_get_pkt_timebase((*C.struct_AVCodecContext)(ctxt)))
 }
 
-func (ctxt *Context) AvCodecSetPktTimebase(r Rational) {
+func (ctxt *CodecContext) AvCodecSetPktTimebase(r Rational) {
 	C.av_codec_set_pkt_timebase((*C.struct_AVCodecContext)(ctxt), (C.struct_AVRational)(r))
 }
 
-func (ctxt *Context) AvCodecGetCodecDescriptor() *Descriptor {
+func (ctxt *CodecContext) AvCodecGetCodecDescriptor() *Descriptor {
 	return (*Descriptor)(C.av_codec_get_codec_descriptor((*C.struct_AVCodecContext)(ctxt)))
 }
 
-func (ctxt *Context) AvCodecSetCodecDescriptor(d *Descriptor) {
+func (ctxt *CodecContext) AvCodecSetCodecDescriptor(d *Descriptor) {
 	C.av_codec_set_codec_descriptor((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVCodecDescriptor)(d))
 }
 
-func (ctxt *Context) AvCodecGetLowres() int {
+func (ctxt *CodecContext) AvCodecGetLowres() int {
 	return int(C.av_codec_get_lowres((*C.struct_AVCodecContext)(ctxt)))
 }
 
-func (ctxt *Context) AvCodecSetLowres(i int) {
+func (ctxt *CodecContext) AvCodecSetLowres(i int) {
 	C.av_codec_set_lowres((*C.struct_AVCodecContext)(ctxt), C.int(i))
 }
 
-func (ctxt *Context) AvCodecGetSeekPreroll() int {
+func (ctxt *CodecContext) AvCodecGetSeekPreroll() int {
 	return int(C.av_codec_get_seek_preroll((*C.struct_AVCodecContext)(ctxt)))
 }
 
-func (ctxt *Context) AvCodecSetSeekPreroll(i int) {
+func (ctxt *CodecContext) AvCodecSetSeekPreroll(i int) {
 	C.av_codec_set_seek_preroll((*C.struct_AVCodecContext)(ctxt), C.int(i))
 }
 
-func (ctxt *Context) AvCodecGetChromaIntraMatrix() *uint16 {
+func (ctxt *CodecContext) AvCodecGetChromaIntraMatrix() *uint16 {
 	return (*uint16)(C.av_codec_get_chroma_intra_matrix((*C.struct_AVCodecContext)(ctxt)))
 }
 
-func (ctxt *Context) AvCodecSetChromaIntraMatrix(t *uint16) {
+func (ctxt *CodecContext) AvCodecSetChromaIntraMatrix(t *uint16) {
 	C.av_codec_set_chroma_intra_matrix((*C.struct_AVCodecContext)(ctxt), (*C.uint16_t)(t))
 }
 
 //Free the codec context and everything associated with it and write NULL to the provided pointer.
-func (ctxt *Context) AvcodecFreeContext() {
+func (ctxt *CodecContext) AvcodecFreeContext() {
 	C.avcodec_free_context((**C.struct_AVCodecContext)(unsafe.Pointer(ctxt)))
 }
 
 //Set the fields of the given Context to default values corresponding to the given codec (defaults may be codec-dependent).
-func (ctxt *Context) AvcodecGetContextDefaults3(c *Codec) int {
+func (ctxt *CodecContext) AvcodecGetContextDefaults3(c *Codec) int {
 	return int(C.avcodec_get_context_defaults3((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVCodec)(c)))
 }
 
 //Copy the settings of the source Context into the destination Context.
-func (ctxt *Context) AvcodecCopyContext(ctxt2 *Context) int {
+func (ctxt *CodecContext) AvcodecCopyContext(ctxt2 *CodecContext) int {
 	return int(C.avcodec_copy_context((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVCodecContext)(ctxt2)))
 }
 
 //Initialize the Context to use the given Codec
-func (ctxt *Context) AvcodecOpen2(c *Codec, d **Dictionary) int {
+func (ctxt *CodecContext) AvcodecOpen2(c *Codec, d **Dictionary) int {
 	return int(C.avcodec_open2((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVCodec)(c), (**C.struct_AVDictionary)(unsafe.Pointer(d))))
 }
 
 //Close a given Context and free all the data associated with it (but not the Context itself).
-func (ctxt *Context) AvcodecClose() int {
+func (ctxt *CodecContext) AvcodecClose() int {
 	return int(C.avcodec_close((*C.struct_AVCodecContext)(ctxt)))
 }
 
 //The default callback for Context.get_buffer2().
-func (s *Context) AvcodecDefaultGetBuffer2(f *Frame, l int) int {
+func (s *CodecContext) AvcodecDefaultGetBuffer2(f *Frame, l int) int {
 	return int(C.avcodec_default_get_buffer2((*C.struct_AVCodecContext)(s), (*C.struct_AVFrame)(f), C.int(l)))
 }
 
 //Modify width and height values so that they will result in a memory buffer that is acceptable for the codec if you do not use any horizontal padding.
-func (ctxt *Context) AvcodecAlignDimensions(w, h *int) {
+func (ctxt *CodecContext) AvcodecAlignDimensions(w, h *int) {
 	C.avcodec_align_dimensions((*C.struct_AVCodecContext)(ctxt), (*C.int)(unsafe.Pointer(w)), (*C.int)(unsafe.Pointer(h)))
 }
 
 //Modify width and height values so that they will result in a memory buffer that is acceptable for the codec if you also ensure that all line sizes are a multiple of the respective linesize_align[i].
-func (ctxt *Context) AvcodecAlignDimensions2(w, h *int, l int) {
+func (ctxt *CodecContext) AvcodecAlignDimensions2(w, h *int, l int) {
 	C.avcodec_align_dimensions2((*C.struct_AVCodecContext)(ctxt), (*C.int)(unsafe.Pointer(w)), (*C.int)(unsafe.Pointer(h)), (*C.int)(unsafe.Pointer(&l)))
 }
 
 //Decode the audio frame of size avpkt->size from avpkt->data into frame.
-func (ctxt *Context) AvcodecDecodeAudio4(f *Frame, g *int, a *Packet) int {
+func (ctxt *CodecContext) AvcodecDecodeAudio4(f *Frame, g *int, a *Packet) int {
 	return int(C.avcodec_decode_audio4((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVFrame)(f), (*C.int)(unsafe.Pointer(g)), (*C.struct_AVPacket)(a)))
 }
 
 //Decode the video frame of size avpkt->size from avpkt->data into picture.
-func (ctxt *Context) AvcodecDecodeVideo2(p *Frame, g *int, a *Packet) int {
+func (ctxt *CodecContext) AvcodecDecodeVideo2(p *Frame, g *int, a *Packet) int {
 	return int(C.avcodec_decode_video2((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVFrame)(p), (*C.int)(unsafe.Pointer(g)), (*C.struct_AVPacket)(a)))
 }
 
 //Decode a subtitle message.
-func (ctxt *Context) AvcodecDecodeSubtitle2(s *AvSubtitle, g *int, a *Packet) int {
+func (ctxt *CodecContext) AvcodecDecodeSubtitle2(s *AvSubtitle, g *int, a *Packet) int {
 	return int(C.avcodec_decode_subtitle2((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVSubtitle)(s), (*C.int)(unsafe.Pointer(g)), (*C.struct_AVPacket)(a)))
 }
 
 //Encode a frame of audio.
-func (ctxt *Context) AvcodecEncodeAudio2(p *Packet, f *Frame, gp *int) int {
+func (ctxt *CodecContext) AvcodecEncodeAudio2(p *Packet, f *Frame, gp *int) int {
 	return int(C.avcodec_encode_audio2((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVPacket)(p), (*C.struct_AVFrame)(f), (*C.int)(unsafe.Pointer(gp))))
 }
 
 //Encode a frame of video
-func (ctxt *Context) AvcodecEncodeVideo2(p *Packet, f *Frame, gp *int) int {
+func (ctxt *CodecContext) AvcodecEncodeVideo2(p *Packet, f *Frame, gp *int) int {
 	return int(C.avcodec_encode_video2((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVPacket)(p), (*C.struct_AVFrame)(f), (*C.int)(unsafe.Pointer(gp))))
 }
 
-func (ctxt *Context) AvcodecEncodeSubtitle(b *uint8, bs int, s *AvSubtitle) int {
+func (ctxt *CodecContext) AvcodecEncodeSubtitle(b *uint8, bs int, s *AvSubtitle) int {
 	return int(C.avcodec_encode_subtitle((*C.struct_AVCodecContext)(ctxt), (*C.uint8_t)(b), C.int(bs), (*C.struct_AVSubtitle)(s)))
 }
 
-func (ctxt *Context) AvcodecDefaultGetFormat(f *PixelFormat) PixelFormat {
+func (ctxt *CodecContext) AvcodecDefaultGetFormat(f *PixelFormat) PixelFormat {
 	return (PixelFormat)(C.avcodec_default_get_format((*C.struct_AVCodecContext)(ctxt), (*C.enum_AVPixelFormat)(f)))
 }
 
 //Reset the internal decoder state / flush internal buffers.
-func (ctxt *Context) AvcodecFlushBuffers() {
+func (ctxt *CodecContext) AvcodecFlushBuffers() {
 	C.avcodec_flush_buffers((*C.struct_AVCodecContext)(ctxt))
 }
 
 //Return audio frame duration.
-func (ctxt *Context) AvGetAudioFrameDuration(f int) int {
+func (ctxt *CodecContext) AvGetAudioFrameDuration(f int) int {
 	return int(C.av_get_audio_frame_duration((*C.struct_AVCodecContext)(ctxt), C.int(f)))
 }
 
-func (ctxt *Context) AvcodecIsOpen() int {
+func (ctxt *CodecContext) AvcodecIsOpen() int {
 	return int(C.avcodec_is_open((*C.struct_AVCodecContext)(ctxt)))
 }
 
 //Parse a packet.
-func (ctxt *Context) AvParserParse2(ctxtp *ParserContext, p **uint8, ps *int, b *uint8, bs int, pt, dt, po int64) int {
+func (ctxt *CodecContext) AvParserParse2(ctxtp *ParserContext, p **uint8, ps *int, b *uint8, bs int, pt, dt, po int64) int {
 	return int(C.av_parser_parse2((*C.struct_AVCodecParserContext)(ctxtp), (*C.struct_AVCodecContext)(ctxt), (**C.uint8_t)(unsafe.Pointer(p)), (*C.int)(unsafe.Pointer(ps)), (*C.uint8_t)(b), C.int(bs), (C.int64_t)(pt), (C.int64_t)(dt), (C.int64_t)(po)))
 }
 
-func (ctxt *Context) AvParserChange(ctxtp *ParserContext, pb **uint8, pbs *int, b *uint8, bs, k int) int {
+func (ctxt *CodecContext) AvParserChange(ctxtp *ParserContext, pb **uint8, pbs *int, b *uint8, bs, k int) int {
 	return int(C.av_parser_change((*C.struct_AVCodecParserContext)(ctxtp), (*C.struct_AVCodecContext)(ctxt), (**C.uint8_t)(unsafe.Pointer(pb)), (*C.int)(unsafe.Pointer(pbs)), (*C.uint8_t)(b), C.int(bs), C.int(k)))
 }
 

--- a/avcodec/context_struct.go
+++ b/avcodec/context_struct.go
@@ -3,546 +3,550 @@
 
 package avcodec
 
-func (ctxt *Context) ActiveThreadType() int {
+import (
+	"github.com/giorgisio/goav/avutil"
+)
+
+func (ctxt *CodecContext) ActiveThreadType() int {
 	return int(ctxt.active_thread_type)
 }
 
-func (ctxt *Context) BFrameStrategy() int {
+func (ctxt *CodecContext) BFrameStrategy() int {
 	return int(ctxt.b_frame_strategy)
 }
 
-func (ctxt *Context) BQuantFactor() float64 {
+func (ctxt *CodecContext) BQuantFactor() float64 {
 	return float64(ctxt.b_quant_factor)
 }
 
-func (ctxt *Context) BQuantOffset() float64 {
+func (ctxt *CodecContext) BQuantOffset() float64 {
 	return float64(ctxt.b_quant_offset)
 }
 
-func (ctxt *Context) BSensitivity() int {
+func (ctxt *CodecContext) BSensitivity() int {
 	return int(ctxt.b_sensitivity)
 }
 
-func (ctxt *Context) BidirRefine() int {
+func (ctxt *CodecContext) BidirRefine() int {
 	return int(ctxt.bidir_refine)
 }
 
-func (ctxt *Context) BitRate() int {
+func (ctxt *CodecContext) BitRate() int {
 	return int(ctxt.bit_rate)
 }
 
-func (ctxt *Context) BitRateTolerance() int {
+func (ctxt *CodecContext) BitRateTolerance() int {
 	return int(ctxt.bit_rate_tolerance)
 }
 
-func (ctxt *Context) BitsPerCodedSample() int {
+func (ctxt *CodecContext) BitsPerCodedSample() int {
 	return int(ctxt.bits_per_coded_sample)
 }
 
-func (ctxt *Context) BitsPerRawSample() int {
+func (ctxt *CodecContext) BitsPerRawSample() int {
 	return int(ctxt.bits_per_raw_sample)
 }
 
-func (ctxt *Context) BlockAlign() int {
+func (ctxt *CodecContext) BlockAlign() int {
 	return int(ctxt.block_align)
 }
 
-func (ctxt *Context) BrdScale() int {
+func (ctxt *CodecContext) BrdScale() int {
 	return int(ctxt.brd_scale)
 }
 
-func (ctxt *Context) Channels() int {
+func (ctxt *CodecContext) Channels() int {
 	return int(ctxt.channels)
 }
 
-func (ctxt *Context) Chromaoffset() int {
+func (ctxt *CodecContext) Chromaoffset() int {
 	return int(ctxt.chromaoffset)
 }
 
-func (ctxt *Context) CodedHeight() int {
+func (ctxt *CodecContext) CodedHeight() int {
 	return int(ctxt.coded_height)
 }
 
-func (ctxt *Context) CodedWidth() int {
+func (ctxt *CodecContext) CodedWidth() int {
 	return int(ctxt.coded_width)
 }
 
-func (ctxt *Context) CoderType() int {
+func (ctxt *CodecContext) CoderType() int {
 	return int(ctxt.coder_type)
 }
 
-func (ctxt *Context) CompressionLevel() int {
+func (ctxt *CodecContext) CompressionLevel() int {
 	return int(ctxt.compression_level)
 }
 
-func (ctxt *Context) ContextModel() int {
+func (ctxt *CodecContext) ContextModel() int {
 	return int(ctxt.context_model)
 }
 
-func (ctxt *Context) Cutoff() int {
+func (ctxt *CodecContext) Cutoff() int {
 	return int(ctxt.cutoff)
 }
 
-func (ctxt *Context) DarkMasking() float64 {
+func (ctxt *CodecContext) DarkMasking() float64 {
 	return float64(ctxt.dark_masking)
 }
 
-func (ctxt *Context) DctAlgo() int {
+func (ctxt *CodecContext) DctAlgo() int {
 	return int(ctxt.dct_algo)
 }
 
-func (ctxt *Context) Debug() int {
+func (ctxt *CodecContext) Debug() int {
 	return int(ctxt.debug)
 }
 
-func (ctxt *Context) DebugMv() int {
+func (ctxt *CodecContext) DebugMv() int {
 	return int(ctxt.debug_mv)
 }
 
-func (ctxt *Context) Delay() int {
+func (ctxt *CodecContext) Delay() int {
 	return int(ctxt.delay)
 }
 
-func (ctxt *Context) DiaSize() int {
+func (ctxt *CodecContext) DiaSize() int {
 	return int(ctxt.dia_size)
 }
 
-func (ctxt *Context) ErrRecognition() int {
+func (ctxt *CodecContext) ErrRecognition() int {
 	return int(ctxt.err_recognition)
 }
 
-func (ctxt *Context) ErrorConcealment() int {
+func (ctxt *CodecContext) ErrorConcealment() int {
 	return int(ctxt.error_concealment)
 }
 
-func (ctxt *Context) ExtradataSize() int {
+func (ctxt *CodecContext) ExtradataSize() int {
 	return int(ctxt.extradata_size)
 }
 
-func (ctxt *Context) Flags() int {
+func (ctxt *CodecContext) Flags() int {
 	return int(ctxt.flags)
 }
 
-func (ctxt *Context) Flags2() int {
+func (ctxt *CodecContext) Flags2() int {
 	return int(ctxt.flags2)
 }
 
-func (ctxt *Context) FrameBits() int {
+func (ctxt *CodecContext) FrameBits() int {
 	return int(ctxt.frame_bits)
 }
 
-func (ctxt *Context) FrameNumber() int {
+func (ctxt *CodecContext) FrameNumber() int {
 	return int(ctxt.frame_number)
 }
 
-func (ctxt *Context) FrameSize() int {
+func (ctxt *CodecContext) FrameSize() int {
 	return int(ctxt.frame_size)
 }
 
-func (ctxt *Context) FrameSkipCmp() int {
+func (ctxt *CodecContext) FrameSkipCmp() int {
 	return int(ctxt.frame_skip_cmp)
 }
 
-func (ctxt *Context) FrameSkipExp() int {
+func (ctxt *CodecContext) FrameSkipExp() int {
 	return int(ctxt.frame_skip_exp)
 }
 
-func (ctxt *Context) FrameSkipFactor() int {
+func (ctxt *CodecContext) FrameSkipFactor() int {
 	return int(ctxt.frame_skip_factor)
 }
 
-func (ctxt *Context) FrameSkipThreshold() int {
+func (ctxt *CodecContext) FrameSkipThreshold() int {
 	return int(ctxt.frame_skip_threshold)
 }
 
-func (ctxt *Context) GlobalQuality() int {
+func (ctxt *CodecContext) GlobalQuality() int {
 	return int(ctxt.global_quality)
 }
 
-func (ctxt *Context) GopSize() int {
+func (ctxt *CodecContext) GopSize() int {
 	return int(ctxt.gop_size)
 }
 
-func (ctxt *Context) HasBFrames() int {
+func (ctxt *CodecContext) HasBFrames() int {
 	return int(ctxt.has_b_frames)
 }
 
-func (ctxt *Context) HeaderBits() int {
+func (ctxt *CodecContext) HeaderBits() int {
 	return int(ctxt.header_bits)
 }
 
-func (ctxt *Context) Height() int {
+func (ctxt *CodecContext) Height() int {
 	return int(ctxt.height)
 }
 
-func (ctxt *Context) ICount() int {
+func (ctxt *CodecContext) ICount() int {
 	return int(ctxt.i_count)
 }
 
-func (ctxt *Context) IQuantFactor() float64 {
+func (ctxt *CodecContext) IQuantFactor() float64 {
 	return float64(ctxt.i_quant_factor)
 }
 
-func (ctxt *Context) IQuantOffset() float64 {
+func (ctxt *CodecContext) IQuantOffset() float64 {
 	return float64(ctxt.i_quant_offset)
 }
 
-func (ctxt *Context) ITexBits() int {
+func (ctxt *CodecContext) ITexBits() int {
 	return int(ctxt.i_tex_bits)
 }
 
-func (ctxt *Context) IdctAlgo() int {
+func (ctxt *CodecContext) IdctAlgo() int {
 	return int(ctxt.idct_algo)
 }
 
-func (ctxt *Context) IldctCmp() int {
+func (ctxt *CodecContext) IldctCmp() int {
 	return int(ctxt.ildct_cmp)
 }
 
-func (ctxt *Context) IntraDcPrecision() int {
+func (ctxt *CodecContext) IntraDcPrecision() int {
 	return int(ctxt.intra_dc_precision)
 }
 
-func (ctxt *Context) KeyintMin() int {
+func (ctxt *CodecContext) KeyintMin() int {
 	return int(ctxt.keyint_min)
 }
 
-func (ctxt *Context) LastPredictorCount() int {
+func (ctxt *CodecContext) LastPredictorCount() int {
 	return int(ctxt.last_predictor_count)
 }
 
-func (ctxt *Context) Level() int {
+func (ctxt *CodecContext) Level() int {
 	return int(ctxt.level)
 }
 
-func (ctxt *Context) LogLevelOffset() int {
+func (ctxt *CodecContext) LogLevelOffset() int {
 	return int(ctxt.log_level_offset)
 }
 
-func (ctxt *Context) Lowres() int {
+func (ctxt *CodecContext) Lowres() int {
 	return int(ctxt.lowres)
 }
 
-func (ctxt *Context) LumiMasking() float64 {
+func (ctxt *CodecContext) LumiMasking() float64 {
 	return float64(ctxt.lumi_masking)
 }
 
-func (ctxt *Context) MaxBFrames() int {
+func (ctxt *CodecContext) MaxBFrames() int {
 	return int(ctxt.max_b_frames)
 }
 
-func (ctxt *Context) MaxPredictionOrder() int {
+func (ctxt *CodecContext) MaxPredictionOrder() int {
 	return int(ctxt.max_prediction_order)
 }
 
-func (ctxt *Context) MaxQdiff() int {
+func (ctxt *CodecContext) MaxQdiff() int {
 	return int(ctxt.max_qdiff)
 }
 
-func (ctxt *Context) MbCmp() int {
+func (ctxt *CodecContext) MbCmp() int {
 	return int(ctxt.mb_cmp)
 }
 
-func (ctxt *Context) MbDecision() int {
+func (ctxt *CodecContext) MbDecision() int {
 	return int(ctxt.mb_decision)
 }
 
-func (ctxt *Context) MbLmax() int {
+func (ctxt *CodecContext) MbLmax() int {
 	return int(ctxt.mb_lmax)
 }
 
-func (ctxt *Context) MbLmin() int {
+func (ctxt *CodecContext) MbLmin() int {
 	return int(ctxt.mb_lmin)
 }
 
-func (ctxt *Context) MeCmp() int {
+func (ctxt *CodecContext) MeCmp() int {
 	return int(ctxt.me_cmp)
 }
 
-func (ctxt *Context) MePenaltyCompensation() int {
+func (ctxt *CodecContext) MePenaltyCompensation() int {
 	return int(ctxt.me_penalty_compensation)
 }
 
-func (ctxt *Context) MePreCmp() int {
+func (ctxt *CodecContext) MePreCmp() int {
 	return int(ctxt.me_pre_cmp)
 }
 
-func (ctxt *Context) MeRange() int {
+func (ctxt *CodecContext) MeRange() int {
 	return int(ctxt.me_range)
 }
 
-func (ctxt *Context) MeSubCmp() int {
+func (ctxt *CodecContext) MeSubCmp() int {
 	return int(ctxt.me_sub_cmp)
 }
 
-func (ctxt *Context) MeSubpelQuality() int {
+func (ctxt *CodecContext) MeSubpelQuality() int {
 	return int(ctxt.me_subpel_quality)
 }
 
-func (ctxt *Context) MinPredictionOrder() int {
+func (ctxt *CodecContext) MinPredictionOrder() int {
 	return int(ctxt.min_prediction_order)
 }
 
-func (ctxt *Context) MiscBits() int {
+func (ctxt *CodecContext) MiscBits() int {
 	return int(ctxt.misc_bits)
 }
 
-func (ctxt *Context) MpegQuant() int {
+func (ctxt *CodecContext) MpegQuant() int {
 	return int(ctxt.mpeg_quant)
 }
 
-func (ctxt *Context) Mv0Threshold() int {
+func (ctxt *CodecContext) Mv0Threshold() int {
 	return int(ctxt.mv0_threshold)
 }
 
-func (ctxt *Context) MvBits() int {
+func (ctxt *CodecContext) MvBits() int {
 	return int(ctxt.mv_bits)
 }
 
-func (ctxt *Context) NoiseReduction() int {
+func (ctxt *CodecContext) NoiseReduction() int {
 	return int(ctxt.noise_reduction)
 }
 
-func (ctxt *Context) NsseWeight() int {
+func (ctxt *CodecContext) NsseWeight() int {
 	return int(ctxt.nsse_weight)
 }
 
-func (ctxt *Context) PCount() int {
+func (ctxt *CodecContext) PCount() int {
 	return int(ctxt.p_count)
 }
 
-func (ctxt *Context) PMasking() float64 {
+func (ctxt *CodecContext) PMasking() float64 {
 	return float64(ctxt.p_masking)
 }
 
-func (ctxt *Context) PTexBits() int {
+func (ctxt *CodecContext) PTexBits() int {
 	return int(ctxt.p_tex_bits)
 }
 
-func (ctxt *Context) PreDiaSize() int {
+func (ctxt *CodecContext) PreDiaSize() int {
 	return int(ctxt.pre_dia_size)
 }
 
-func (ctxt *Context) PreMe() int {
+func (ctxt *CodecContext) PreMe() int {
 	return int(ctxt.pre_me)
 }
 
-func (ctxt *Context) PredictionMethod() int {
+func (ctxt *CodecContext) PredictionMethod() int {
 	return int(ctxt.prediction_method)
 }
 
-func (ctxt *Context) Profile() int {
+func (ctxt *CodecContext) Profile() int {
 	return int(ctxt.profile)
 }
 
-func (ctxt *Context) Qblur() float64 {
+func (ctxt *CodecContext) Qblur() float64 {
 	return float64(ctxt.qblur)
 }
 
-func (ctxt *Context) Qcompress() float64 {
+func (ctxt *CodecContext) Qcompress() float64 {
 	return float64(ctxt.qcompress)
 }
 
-func (ctxt *Context) Qmax() int {
+func (ctxt *CodecContext) Qmax() int {
 	return int(ctxt.qmax)
 }
 
-func (ctxt *Context) Qmin() int {
+func (ctxt *CodecContext) Qmin() int {
 	return int(ctxt.qmin)
 }
 
-func (ctxt *Context) RcBufferSize() int {
+func (ctxt *CodecContext) RcBufferSize() int {
 	return int(ctxt.rc_buffer_size)
 }
 
-func (ctxt *Context) RcInitialBufferOccupancy() int {
+func (ctxt *CodecContext) RcInitialBufferOccupancy() int {
 	return int(ctxt.rc_initial_buffer_occupancy)
 }
 
-func (ctxt *Context) RcMaxAvailableVbvUse() float64 {
+func (ctxt *CodecContext) RcMaxAvailableVbvUse() float64 {
 	return float64(ctxt.rc_max_available_vbv_use)
 }
 
-func (ctxt *Context) RcMaxRate() int {
+func (ctxt *CodecContext) RcMaxRate() int {
 	return int(ctxt.rc_max_rate)
 }
 
-func (ctxt *Context) RcMinRate() int {
+func (ctxt *CodecContext) RcMinRate() int {
 	return int(ctxt.rc_min_rate)
 }
 
-func (ctxt *Context) RcMinVbvOverflowUse() float64 {
+func (ctxt *CodecContext) RcMinVbvOverflowUse() float64 {
 	return float64(ctxt.rc_min_vbv_overflow_use)
 }
 
-func (ctxt *Context) RcOverrideCount() int {
+func (ctxt *CodecContext) RcOverrideCount() int {
 	return int(ctxt.rc_override_count)
 }
 
-func (ctxt *Context) RefcountedFrames() int {
+func (ctxt *CodecContext) RefcountedFrames() int {
 	return int(ctxt.refcounted_frames)
 }
 
-func (ctxt *Context) Refs() int {
+func (ctxt *CodecContext) Refs() int {
 	return int(ctxt.refs)
 }
 
-func (ctxt *Context) RtpPayloadSize() int {
+func (ctxt *CodecContext) RtpPayloadSize() int {
 	return int(ctxt.rtp_payload_size)
 }
 
-func (ctxt *Context) SampleRate() int {
+func (ctxt *CodecContext) SampleRate() int {
 	return int(ctxt.sample_rate)
 }
 
-func (ctxt *Context) ScenechangeThreshold() int {
+func (ctxt *CodecContext) ScenechangeThreshold() int {
 	return int(ctxt.scenechange_threshold)
 }
 
-func (ctxt *Context) SeekPreroll() int {
+func (ctxt *CodecContext) SeekPreroll() int {
 	return int(ctxt.seek_preroll)
 }
 
-func (ctxt *Context) SideDataOnlyPackets() int {
+func (ctxt *CodecContext) SideDataOnlyPackets() int {
 	return int(ctxt.side_data_only_packets)
 }
 
-func (ctxt *Context) SkipAlpha() int {
+func (ctxt *CodecContext) SkipAlpha() int {
 	return int(ctxt.skip_alpha)
 }
 
-func (ctxt *Context) SkipBottom() int {
+func (ctxt *CodecContext) SkipBottom() int {
 	return int(ctxt.skip_bottom)
 }
 
-func (ctxt *Context) SkipCount() int {
+func (ctxt *CodecContext) SkipCount() int {
 	return int(ctxt.skip_count)
 }
 
-func (ctxt *Context) SkipTop() int {
+func (ctxt *CodecContext) SkipTop() int {
 	return int(ctxt.skip_top)
 }
 
-func (ctxt *Context) SliceCount() int {
+func (ctxt *CodecContext) SliceCount() int {
 	return int(ctxt.slice_count)
 }
 
-func (ctxt *Context) SliceFlags() int {
+func (ctxt *CodecContext) SliceFlags() int {
 	return int(ctxt.slice_flags)
 }
 
-func (ctxt *Context) Slices() int {
+func (ctxt *CodecContext) Slices() int {
 	return int(ctxt.slices)
 }
 
-func (ctxt *Context) SpatialCplxMasking() float64 {
+func (ctxt *CodecContext) SpatialCplxMasking() float64 {
 	return float64(ctxt.spatial_cplx_masking)
 }
 
-func (ctxt *Context) StrictStdCompliance() int {
+func (ctxt *CodecContext) StrictStdCompliance() int {
 	return int(ctxt.strict_std_compliance)
 }
 
-func (ctxt *Context) SubCharencMode() int {
+func (ctxt *CodecContext) SubCharencMode() int {
 	return int(ctxt.sub_charenc_mode)
 }
 
-func (ctxt *Context) SubtitleHeaderSize() int {
+func (ctxt *CodecContext) SubtitleHeaderSize() int {
 	return int(ctxt.subtitle_header_size)
 }
 
-func (ctxt *Context) TemporalCplxMasking() float64 {
+func (ctxt *CodecContext) TemporalCplxMasking() float64 {
 	return float64(ctxt.temporal_cplx_masking)
 }
 
-func (ctxt *Context) ThreadCount() int {
+func (ctxt *CodecContext) ThreadCount() int {
 	return int(ctxt.thread_count)
 }
 
-func (ctxt *Context) ThreadSafeCallbacks() int {
+func (ctxt *CodecContext) ThreadSafeCallbacks() int {
 	return int(ctxt.thread_safe_callbacks)
 }
 
-func (ctxt *Context) ThreadType() int {
+func (ctxt *CodecContext) ThreadType() int {
 	return int(ctxt.thread_type)
 }
 
-func (ctxt *Context) TicksPerFrame() int {
+func (ctxt *CodecContext) TicksPerFrame() int {
 	return int(ctxt.ticks_per_frame)
 }
 
-func (ctxt *Context) Trellis() int {
+func (ctxt *CodecContext) Trellis() int {
 	return int(ctxt.trellis)
 }
 
-func (ctxt *Context) Width() int {
+func (ctxt *CodecContext) Width() int {
 	return int(ctxt.width)
 }
 
-func (ctxt *Context) WorkaroundBugs() int {
+func (ctxt *CodecContext) WorkaroundBugs() int {
 	return int(ctxt.workaround_bugs)
 }
 
-func (ctxt *Context) AudioServiceType() AvAudioServiceType {
+func (ctxt *CodecContext) AudioServiceType() AvAudioServiceType {
 	return (AvAudioServiceType)(ctxt.audio_service_type)
 }
 
-func (ctxt *Context) ChromaSampleLocation() AvChromaLocation {
+func (ctxt *CodecContext) ChromaSampleLocation() AvChromaLocation {
 	return (AvChromaLocation)(ctxt.chroma_sample_location)
 }
 
-func (ctxt *Context) CodecDescriptor() *Descriptor {
+func (ctxt *CodecContext) CodecDescriptor() *Descriptor {
 	return (*Descriptor)(ctxt.codec_descriptor)
 }
 
-func (ctxt *Context) CodecId() CodecId {
+func (ctxt *CodecContext) CodecId() CodecId {
 	return (CodecId)(ctxt.codec_id)
 }
 
-func (ctxt *Context) CodecType() MediaType {
-	return (MediaType)(ctxt.codec_type)
+func (ctxt *CodecContext) CodecType() avutil.MediaType {
+	return (avutil.MediaType)(ctxt.codec_type)
 }
 
-func (ctxt *Context) ColorPrimaries() AvColorPrimaries {
+func (ctxt *CodecContext) ColorPrimaries() AvColorPrimaries {
 	return (AvColorPrimaries)(ctxt.color_primaries)
 }
 
-func (ctxt *Context) ColorRange() AvColorRange {
+func (ctxt *CodecContext) ColorRange() AvColorRange {
 	return (AvColorRange)(ctxt.color_range)
 }
 
-func (ctxt *Context) ColorTrc() AvColorTransferCharacteristic {
+func (ctxt *CodecContext) ColorTrc() AvColorTransferCharacteristic {
 	return (AvColorTransferCharacteristic)(ctxt.color_trc)
 }
 
-func (ctxt *Context) Colorspace() AvColorSpace {
+func (ctxt *CodecContext) Colorspace() AvColorSpace {
 	return (AvColorSpace)(ctxt.colorspace)
 }
 
-func (ctxt *Context) FieldOrder() AvFieldOrder {
+func (ctxt *CodecContext) FieldOrder() AvFieldOrder {
 	return (AvFieldOrder)(ctxt.field_order)
 }
 
-func (ctxt *Context) PixFmt() PixelFormat {
+func (ctxt *CodecContext) PixFmt() PixelFormat {
 	return (PixelFormat)(ctxt.pix_fmt)
 }
 
-func (ctxt *Context) RequestSampleFmt() AvSampleFormat {
+func (ctxt *CodecContext) RequestSampleFmt() AvSampleFormat {
 	return (AvSampleFormat)(ctxt.request_sample_fmt)
 }
 
-func (ctxt *Context) SampleFmt() AvSampleFormat {
+func (ctxt *CodecContext) SampleFmt() AvSampleFormat {
 	return (AvSampleFormat)(ctxt.sample_fmt)
 }
 
-func (ctxt *Context) SkipFrame() AvDiscard {
+func (ctxt *CodecContext) SkipFrame() AvDiscard {
 	return (AvDiscard)(ctxt.skip_frame)
 }
 
-func (ctxt *Context) SkipIdct() AvDiscard {
+func (ctxt *CodecContext) SkipIdct() AvDiscard {
 	return (AvDiscard)(ctxt.skip_idct)
 }
 
-func (ctxt *Context) SkipLoopFilter() AvDiscard {
+func (ctxt *CodecContext) SkipLoopFilter() AvDiscard {
 	return (AvDiscard)(ctxt.skip_loop_filter)
 }

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -20,6 +20,7 @@ package avformat
 import "C"
 import (
 	"unsafe"
+	"github.com/giorgisio/goav/avutil"
 )
 
 type (
@@ -28,7 +29,6 @@ type (
 	OutputFormat               C.struct_AVOutputFormat
 	Context                    C.struct_AVFormatContext
 	Frame                      C.struct_AVFrame
-	CodecContext               C.struct_AVCodecContext
 	Dictionary                 C.struct_AVDictionary
 	AvIndexEntry               C.struct_AVIndexEntry
 	Stream                     C.struct_AVStream
@@ -48,7 +48,6 @@ type (
 	FFFrac                     C.struct_FFFrac
 	AvStreamParseType          C.enum_AVStreamParseType
 	AvDiscard                  C.enum_AVDiscard
-	MediaType                  C.enum_AVMediaType
 	AvDurationEstimationMethod C.enum_AVDurationEstimationMethod
 	AvPacketSideDataType       C.enum_AVPacketSideDataType
 	CodecId                    C.enum_AVCodecID
@@ -175,7 +174,7 @@ func AvGuessFormat(sn, f, mt string) *OutputFormat {
 }
 
 //Guess the codec ID based upon muxer and filename.
-func AvGuessCodec(fmt *OutputFormat, sn, f, mt string, t MediaType) CodecId {
+func AvGuessCodec(fmt *OutputFormat, sn, f, mt string, t avutil.MediaType) CodecId {
 	return (CodecId)(C.av_guess_codec((*C.struct_AVOutputFormat)(fmt), C.CString(sn), C.CString(f), C.CString(mt), (C.enum_AVMediaType)(t)))
 }
 

--- a/avformat/context.go
+++ b/avformat/context.go
@@ -8,6 +8,7 @@ package avformat
 import "C"
 import (
 	"github.com/giorgisio/goav/avcodec"
+	"github.com/giorgisio/goav/avutil"
 	"unsafe"
 )
 
@@ -90,7 +91,7 @@ func (s *Context) AvFindProgramFromStream(l *AvProgram, su int) *AvProgram {
 }
 
 //Find the "best" stream in the file.
-func AvFindBestStream(ic *Context, t MediaType, ws, rs int, c **AvCodec, f int) int {
+func AvFindBestStream(ic *Context, t avutil.MediaType, ws, rs int, c **AvCodec, f int) int {
 	return int(C.av_find_best_stream((*C.struct_AVFormatContext)(ic), (C.enum_AVMediaType)(t), C.int(ws), C.int(rs), (**C.struct_AVCodec)(unsafe.Pointer(c)), C.int(f)))
 }
 

--- a/avformat/context_struct.go
+++ b/avformat/context_struct.go
@@ -10,8 +10,6 @@ import (
 	"unsafe"
 )
 
-type IO C.struct_AVCodecContext
-
 func (ctxt *Context) Chapters() **AvChapter {
 	return (**AvChapter)(unsafe.Pointer(ctxt.chapters))
 }

--- a/avformat/context_struct.go
+++ b/avformat/context_struct.go
@@ -10,6 +10,8 @@ import (
 	"unsafe"
 )
 
+type IO C.struct_AVCodecContext
+
 func (ctxt *Context) Chapters() **AvChapter {
 	return (**AvChapter)(unsafe.Pointer(ctxt.chapters))
 }
@@ -46,8 +48,9 @@ func (ctxt *Context) Programs() **AvProgram {
 	return (**AvProgram)(unsafe.Pointer(ctxt.programs))
 }
 
-func (ctxt *Context) Streams() *Stream {
-	return (*Stream)(unsafe.Pointer(ctxt.streams))
+func (ctxt *Context) Streams(i uint) *Stream {
+	offset := (unsafe.Sizeof(unsafe.Pointer(*ctxt.streams)) * uintptr(i))
+	return *(** Stream)(unsafe.Pointer(uintptr(unsafe.Pointer(ctxt.streams)) + offset ))
 }
 
 func (ctxt *Context) Filename() string {

--- a/avformat/stream_struct.go
+++ b/avformat/stream_struct.go
@@ -8,10 +8,11 @@ package avformat
 import "C"
 import (
 	"unsafe"
+	"github.com/giorgisio/goav/avcodec"
 )
 
-func (avs *Stream) Codec() *CodecContext {
-	return (*CodecContext)(unsafe.Pointer(avs.codec))
+func (avs *Stream) Codec() *avcodec.CodecContext {
+	return (*avcodec.CodecContext)(unsafe.Pointer(avs.codec))
 }
 
 func (avs *Stream) Metadata() *Dictionary {

--- a/avutil/media_types.go
+++ b/avutil/media_types.go
@@ -1,0 +1,18 @@
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// Farid Zakaria (farid.m.zakaria@gmail.com)
+
+package avutil
+
+//#cgo pkg-config: libavutil
+//#include <libavutil/avutil.h>
+import "C"
+
+const (
+	AVMEDIA_TYPE_UNKNOWN    = C.AVMEDIA_TYPE_UNKNOWN
+	AVMEDIA_TYPE_VIDEO      = C.AVMEDIA_TYPE_VIDEO
+	AVMEDIA_TYPE_AUDIO      = C.AVMEDIA_TYPE_AUDIO
+	AVMEDIA_TYPE_DATA       = C.AVMEDIA_TYPE_DATA
+	AVMEDIA_TYPE_SUBTITLE   = C.AVMEDIA_TYPE_SUBTITLE
+	AVMEDIA_TYPE_ATTACHMENT = C.AVMEDIA_TYPE_ATTACHMENT
+	AVMEDIA_TYPE_NB         = C.AVMEDIA_TYPE_NB
+)

--- a/example/basic.go
+++ b/example/basic.go
@@ -1,0 +1,50 @@
+package main
+
+import "C"
+import "github.com/giorgisio/goav/avutil"
+import "github.com/giorgisio/goav/avformat"
+import "github.com/giorgisio/goav/avfilter"
+import "log"
+
+/**
+  The purpose of this file is to scale and change the bitrate of a given file.
+
+  Useful links that help understand what is going on:
+
+  1. http://dranger.com/ffmpeg/tutorial01.html
+**/
+func main() {
+
+	filename := "sample.mp4"
+
+	var (
+		ctxtFormat *avformat.Context
+	)
+
+	// Register all formats and codecs
+	avformat.AvRegisterAll()
+
+	avfilter.AvfilterRegisterAll()
+
+	// Open video file
+	if avformat.AvformatOpenInput(&ctxtFormat, filename, nil, nil) != 0 {
+		log.Println("Error: Couldn't open file.")
+		return
+	}
+
+	// Retrieve stream information
+	//This function populates pFormatCtx->streams with the proper information.
+	if ctxtFormat.AvformatFindStreamInfo(nil) < 0 {
+		log.Println("Error: Couldn't find stream information.")
+		return
+	}
+
+	//We introduce a handy debugging function to show us what's inside
+	// Dump information about file onto standard error
+	ctxtFormat.AvDumpFormat(0, filename, 0)
+
+	for i := uint(0); i < ctxtFormat.NbStreams(); i++ {
+		log.Println(ctxtFormat.Streams(i).Codec().CodecType() == avutil.AVMEDIA_TYPE_VIDEO)
+	}
+
+}


### PR DESCRIPTION
Each sub-package was redefining each type for cgo causing them to
not operate with each other.

ex. a CodecContext created in the avformat package was not actually the
same (and therefore could not use) the methods in the avcodec/context_struct.go file.

This change includes removing a lot of the incorrect redefinitions.
Also added another basic example thats correct and shows a bit  more.