### PR TITLE
fix AvformatCloseInput crash bug

### DIFF
--- a/avformat/context.go
+++ b/avformat/context.go
@@ -122,7 +122,7 @@ func (s *Context) AvReadPause() int {
 
 //Close an opened input Context.
 func (s *Context) AvformatCloseInput() {
-	C.avformat_close_input((**C.struct_AVFormatContext)(unsafe.Pointer(s)))
+	C.avformat_close_input((**C.struct_AVFormatContext)(unsafe.Pointer(&s)))
 }
 
 //Allocate the stream private data and write the stream header to an output media file.


### PR DESCRIPTION
avformat_close_input take a pointer to AVFormatContext *
`void avformat_close_input	(	AVFormatContext ** 	s	)	`

so the previous code will crash.
```
Fatal error: unexpected signal during runtime execution
[signal 0xb code=0x1 addr=0xb01dfacedebac1e pc=0x7fff8dc5db13]

runtime stack:
runtime.throw(0x4236760, 0x2a)
	/usr/local/Cellar/go/1.5.3/libexec/src/runtime/panic.go:527 +0x90
runtime.sigpanic()
	/usr/local/Cellar/go/1.5.3/libexec/src/runtime/sigpanic_unix.go:12 +0x5a

goroutine 6 [syscall, locked to thread]:
runtime.cgocall(0x41315f0, 0xc820031e20, 0xc800000000)
	/usr/local/Cellar/go/1.5.3/libexec/src/runtime/cgocall.go:120 +0x11b fp=0xc820031df0 sp=0xc820031dc0
github.com/giorgisio/goav/avformat._Cfunc_avformat_close_input(0x6011800)
	??:0 +0x31 fp=0xc820031e20 sp=0xc820031df0
github.com/giorgisio/goav/avformat.(*Context).AvformatCloseInput(0x6011800)
	/Users/zzz/go/src/github.com/giorgisio/goav/avformat/context.go:125 +0x21 fp=0xc820031e30 sp=0xc820031e20
github.com/zwh8800/Love66/player.(*Player).playRoutine(0xc82000e6c0)
	/Users/zzz/go/src/github.com/zwh8800/Love66/player/player.go:195 +0x862 fp=0xc820031fb8 sp=0xc820031e30
runtime.goexit()
	/usr/local/Cellar/go/1.5.3/libexec/src/runtime/asm_amd64.s:1721 +0x1 fp=0xc820031fc0 sp=0xc820031fb8
created by github.com/zwh8800/Love66/player.(*Player).Play
	/Users/zzz/go/src/github.com/zwh8800/Love66/player/player.go:70 +0x40

goroutine 1 [chan receive]:
testing.RunTests(0x424a290, 0x42f35d0, 0x1, 0x1, 0x1)
	/usr/local/Cellar/go/1.5.3/libexec/src/testing/testing.go:562 +0x8ad
testing.(*M).Run(0xc820065ef8, 0x41ffa90)
	/usr/local/Cellar/go/1.5.3/libexec/src/testing/testing.go:494 +0x70
main.main()
	github.com/zwh8800/Love66/player/_test/_testmain.go:54 +0x116

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/Cellar/go/1.5.3/libexec/src/runtime/asm_amd64.s:1721 +0x1

goroutine 5 [chan receive]:
github.com/zwh8800/Love66/player.(*Player).Stop(0xc82000e6c0)
	/Users/zzz/go/src/github.com/zwh8800/Love66/player/player.go:75 +0x87
github.com/zwh8800/Love66/player.TestPlay(0xc820096000)
	/Users/zzz/go/src/github.com/zwh8800/Love66/player/player_test.go:26 +0x604
testing.tRunner(0xc820096000, 0x42f35d0)
	/usr/local/Cellar/go/1.5.3/libexec/src/testing/testing.go:456 +0x98
created by testing.RunTests
	/usr/local/Cellar/go/1.5.3/libexec/src/testing/testing.go:561 +0x86d

goroutine 18 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/Cellar/go/1.5.3/libexec/src/runtime/asm_amd64.s:1721 +0x1
exit status 2
FAIL	github.com/zwh8800/Love66/player	6.097s
```