### PR TITLE
[AvFormat] Initial implementation for Dictionary, Stream added GetRot…

### DIFF
--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -30,6 +30,7 @@ type (
 	Context                    C.struct_AVFormatContext
 	Frame                      C.struct_AVFrame
 	Dictionary                 C.struct_AVDictionary
+	DictionaryEntry            C.struct_AVDictionaryEntry
 	AvIndexEntry               C.struct_AVIndexEntry
 	Stream                     C.struct_AVStream
 	AvProgram                  C.struct_AVProgram

--- a/avformat/dictionary.go
+++ b/avformat/dictionary.go
@@ -1,0 +1,27 @@
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// Giorgis (habtom@giorgis.io)
+
+package avformat
+
+//#cgo pkg-config: libavutil
+//#include <libavutil/dict.h>
+import "C"
+
+import (
+	//"unsafe"
+)
+
+func (d *Dictionary) Count() int {
+	return int(C.av_dict_count((*C.struct_AVDictionary)(d)))
+}
+
+func (d *Dictionary) Get(key string) *DictionaryEntry {
+	var entry *DictionaryEntry;
+	entry = (*DictionaryEntry)(C.av_dict_get((*C.struct_AVDictionary)(d), C.CString(key), (*C.struct_AVDictionaryEntry)(entry), C.AV_DICT_MATCH_CASE));
+
+	return entry
+}
+
+func (de *DictionaryEntry) Value() string {
+	return C.GoString(de.value)
+}

--- a/avformat/stream.go
+++ b/avformat/stream.go
@@ -17,6 +17,32 @@ func (s *Stream) AvStreamSetRFrameRate(r Rational) {
 	C.av_stream_set_r_frame_rate((*C.struct_AVStream)(s), (C.struct_AVRational)(r))
 }
 
+
+/**
+ * Get rotation of the Stream by
+ * 1. MetaData
+ * 2. Metrix
+ */
+func (s *Stream) GetRotation() int64 {
+	dictionaryEntry := s.Metadata().Get("rotate")
+	if (dictionaryEntry != nil) {
+		value := dictionaryEntry.Value();
+		strings.TrimRight(value, "%")
+
+		rotation, err := strconv.ParseInt(value, 10, 64)
+		if (err == nil) {
+			return rotation
+		}
+	}
+
+	var displaymatrix (*C.uint8_t) = C.av_stream_get_side_data((*C.struct_AVStream)(s), C.AV_PKT_DATA_DISPLAYMATRIX, nil);
+	if (displaymatrix) {
+		return -int64(C.av_display_rotation_get((*C.int32_t)(unsafe.Pointer(displaymatrix))))
+	}
+
+	return 0
+}
+
 //struct CodecParserContext * av_stream_get_parser (const Stream *s)
 func (s *Stream) AvStreamGetParser() *CodecParserContext {
 	return (*CodecParserContext)(C.av_stream_get_parser((*C.struct_AVStream)(s)))


### PR DESCRIPTION
Hey! Thanks you for this awesome library

I was going to get Stream Rotation to use more perfect/custom scale alghoritm

So, I didnt find anything for it

I've added get `GetRotation` method for Stream aka (struct_AVStream) from ffmpeg
And initial api for `Dictionary (C.struct_AVDictionary)` and `DictionaryEntry (C.struct_AVDictionaryEntry)`

Thanks