### PR TITLE
Fix avformat string leaks

### DIFF
--- a/avformat/avformat_test.go
+++ b/avformat/avformat_test.go
@@ -1,0 +1,31 @@
+
+package avformat_test
+
+import (
+	"testing"
+
+	"github.com/giorgisio/goav/avformat"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvUrlSplitWithSufficientSizes(t *testing.T) {
+	url := "rtsp://user:password@example.com:554/path"
+	var port int
+	proto, authorization, hostname, path := avformat.AvUrlSplit(100, 100, 100, &port, 100, url)
+
+	assert.Equal(t, "rtsp", proto)
+	assert.Equal(t, "user:password", authorization)
+	assert.Equal(t, "example.com", hostname)
+	assert.Equal(t, 554, port)
+	assert.Equal(t, "/path", path)
+}
+
+func TestAvUrlSplitWithInsufficientSizes(t *testing.T) {
+	url := "https://user:password@example.com:443/here/is/the/path"
+	proto, authorization, hostname, path := avformat.AvUrlSplit(3, 5, 5, nil, 5, url)
+
+	assert.Equal(t, "ht", proto)
+	assert.Equal(t, "user", authorization)
+	assert.Equal(t, "exam", hostname)
+	assert.Equal(t, "/her", path)
+}

--- a/avformat/context.go
+++ b/avformat/context.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/giorgisio/goav/avcodec"
+	"github.com/giorgisio/goav/avutil"
 )
 
 const (

--- a/avformat/context.go
+++ b/avformat/context.go
@@ -188,7 +188,10 @@ func (s *Context) AvFindDefaultStreamIndex() int {
 
 //Print detailed information about the input or output format, such as duration, bitrate, streams, container, programs, metadata, side data, codec and time base.
 func (s *Context) AvDumpFormat(i int, url string, io int) {
-	C.av_dump_format((*C.struct_AVFormatContext)(unsafe.Pointer(s)), C.int(i), C.CString(url), C.int(io))
+	Curl := C.CString(url)
+	defer C.free(unsafe.Pointer(Curl))
+
+	C.av_dump_format((*C.struct_AVFormatContext)(unsafe.Pointer(s)), C.int(i), Curl, C.int(io))
 }
 
 //Guess the sample aspect ratio of a frame, based on both the stream and the frame aspect ratio.
@@ -203,7 +206,10 @@ func (s *Context) AvGuessFrameRate(st *Stream, fr *Frame) avcodec.Rational {
 
 //Check if the stream st contained in s is matched by the stream specifier spec.
 func (s *Context) AvformatMatchStreamSpecifier(st *Stream, spec string) int {
-	return int(C.avformat_match_stream_specifier((*C.struct_AVFormatContext)(s), (*C.struct_AVStream)(st), C.CString(spec)))
+	Cspec := C.CString(spec)
+	defer C.free(unsafe.Pointer(Cspec))
+
+	return int(C.avformat_match_stream_specifier((*C.struct_AVFormatContext)(s), (*C.struct_AVStream)(st), Cspec))
 }
 
 func (s *Context) AvformatQueueAttachedPictures() int {

--- a/avformat/context_struct.go
+++ b/avformat/context_struct.go
@@ -9,6 +9,8 @@ import "C"
 import (
 	"reflect"
 	"unsafe"
+
+	"github.com/giorgisio/goav/avutil"
 )
 
 func (ctxt *Context) Chapters() **AvChapter {

--- a/avformat/stream_struct.go
+++ b/avformat/stream_struct.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	"github.com/giorgisio/goav/avcodec"
+	"github.com/giorgisio/goav/avutil"
 )
 
 func (avs *Stream) CodecParameters() *avcodec.AvCodecParameters {


### PR DESCRIPTION
Most of the `C.CString` calls are not freed, which causes memory leaks.

Some of the functions that take a char* and a size now only take a size, and return a string. Eg: `AvUrlSplit`, `AvGetFrameFilename`, `AvSdpCreate`.