### PR TITLE
Add methods required for encoding

### DIFF
--- a/avcodec/context.go
+++ b/avcodec/context.go
@@ -194,6 +194,14 @@ func (ctxt *Context) SetEncodeParams(width int, height int, pxlFmt PixelFormat) 
 	ctxt.SetEncodeParams2(width, height, pxlFmt, false /*no b frames*/, 10)
 }
 
+func (ctxt *Context) AvcodecSendFrame(frame *Frame) int {
+	return (int)(C.avcodec_send_frame((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVFrame)(frame)))
+}
+
+func (ctxt *Context) AvcodecReceivePacket(packet *Packet) int {
+	return (int)(C.avcodec_receive_packet((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVPacket)(packet)))
+}
+
 func (ctxt *Context) AvcodecSendPacket(packet *Packet) int {
 	return (int)(C.avcodec_send_packet((*C.struct_AVCodecContext)(ctxt), (*C.struct_AVPacket)(packet)))
 }


### PR DESCRIPTION
These methods are used for encoding video. Usage of these methods is described here:

https://libav.org/documentation/doxygen/master/group__lavc__encdec.html

Example implementation:

https://www.ffmpeg.org/doxygen/trunk/encode_video_8c-example.html