### PR TITLE
bugfix: AvformatNewStream2 improperly sets the denominator for time base

### DIFF
--- a/avformat/context.go
+++ b/avformat/context.go
@@ -222,7 +222,7 @@ func (s *Context) AvformatNewStream2(c *AvCodec) *Stream {
 	stream.codec.width = 640
 	stream.codec.height = 480
 	stream.time_base.num = 1
-	stream.time_base.num = 25
+	stream.time_base.den = 25
 	return stream
 }
 


### PR DESCRIPTION
This PR fixes a bug where the numerator was being set twice rather than numerator/denominator once each.